### PR TITLE
Rename glsl-optimizer's unreachable() macro to GLSL_UNREACHABLE() for C++23 compatibility

### DIFF
--- a/generateParsers.sh
+++ b/generateParsers.sh
@@ -4,6 +4,6 @@ flex --nounistd -osrc/compiler/glsl/glsl_lexer.cpp src/compiler/glsl/glsl_lexer.
 bison -v -o "src/compiler/glsl/glcpp/glcpp-parse.c" -p "glcpp_parser_" --defines=src/compiler/glsl/glcpp/glcpp-parse.h src/compiler/glsl/glcpp/glcpp-parse.y
 bison -v -o "src/compiler/glsl/glsl_parser.cpp" -p "_mesa_glsl_" --defines=src/compiler/glsl/glsl_parser.h src/compiler/glsl/glsl_parser.yy
 
-python "src/compiler/glsl/ir_expression_operation.py" "enum" >src/compiler/glsl/ir_expression_operation.h
-python "src/compiler/glsl/ir_expression_operation.py" "strings" >src/compiler/glsl/ir_expression_operation_strings.h
-python "src/compiler/glsl/ir_expression_operation.py" "constant" >src/compiler/glsl/ir_expression_operation_constant.h
+python3 "src/compiler/glsl/ir_expression_operation.py" "enum" >src/compiler/glsl/ir_expression_operation.h
+python3 "src/compiler/glsl/ir_expression_operation.py" "strings" >src/compiler/glsl/ir_expression_operation_strings.h
+python3 "src/compiler/glsl/ir_expression_operation.py" "constant" >src/compiler/glsl/ir_expression_operation_constant.h

--- a/src/compiler/glsl/ast_function.cpp
+++ b/src/compiler/glsl/ast_function.cpp
@@ -2464,7 +2464,7 @@ ast_function_expression::hir(exec_list *instructions,
       return value;
    }
 
-   unreachable("not reached");
+   UNREACHABLE("not reached");
 }
 
 bool

--- a/src/compiler/glsl/ast_to_hir.cpp
+++ b/src/compiler/glsl/ast_to_hir.cpp
@@ -1413,7 +1413,7 @@ ast_expression::do_hir(exec_list *instructions,
 
    switch (this->oper) {
    case ast_aggregate:
-      unreachable("ast_aggregate: Should never get here.");
+      UNREACHABLE("ast_aggregate: Should never get here.");
 
    case ast_assign: {
       this->subexpressions[0]->set_is_lhs(true);
@@ -2004,13 +2004,13 @@ ast_expression::do_hir(exec_list *instructions,
    }
 
    case ast_unsized_array_dim:
-      unreachable("ast_unsized_array_dim: Should never get here.");
+      UNREACHABLE("ast_unsized_array_dim: Should never get here.");
 
    case ast_function_call:
       /* Should *NEVER* get here.  ast_function_call should always be handled
        * by ast_function_expression::hir.
        */
-      unreachable("ast_function_call: handled elsewhere ");
+      UNREACHABLE("ast_function_call: handled elsewhere ");
 
    case ast_identifier: {
       /* ast_identifier can appear several places in a full abstract syntax
@@ -2225,10 +2225,10 @@ ast_expression::has_sequence_subexpression() const
       return false;
 
    case ast_function_call:
-      unreachable("should be handled by ast_function_expression::hir");
+      UNREACHABLE("should be handled by ast_function_expression::hir");
 
    case ast_unsized_array_dim:
-      unreachable("ast_unsized_array_dim: Should never get here.");
+      UNREACHABLE("ast_unsized_array_dim: Should never get here.");
    }
 
    return false;
@@ -2529,7 +2529,7 @@ get_type_name_for_precision_qualifier(const glsl_type *type)
             return names[type_idx];
          }
          default:
-            unreachable("Unsupported sampler/image dimensionality");
+            UNREACHABLE("Unsupported sampler/image dimensionality");
          } /* sampler/image float dimensionality */
          break;
       case GLSL_TYPE_INT:
@@ -2584,7 +2584,7 @@ get_type_name_for_precision_qualifier(const glsl_type *type)
             return names[offset + type_idx];
          }
          default:
-            unreachable("Unsupported isampler/iimage dimensionality");
+            UNREACHABLE("Unsupported isampler/iimage dimensionality");
          } /* sampler/image int dimensionality */
          break;
       case GLSL_TYPE_UINT:
@@ -2639,17 +2639,17 @@ get_type_name_for_precision_qualifier(const glsl_type *type)
             return names[offset + type_idx];
          }
          default:
-            unreachable("Unsupported usampler/uimage dimensionality");
+            UNREACHABLE("Unsupported usampler/uimage dimensionality");
          } /* sampler/image uint dimensionality */
          break;
       default:
-         unreachable("Unsupported sampler/image type");
+         UNREACHABLE("Unsupported sampler/image type");
       } /* sampler/image type */
       break;
    } /* GLSL_TYPE_SAMPLER/GLSL_TYPE_IMAGE */
    break;
    default:
-      unreachable("Unsupported type");
+      UNREACHABLE("Unsupported type");
    } /* base type */
 }
 
@@ -5013,7 +5013,7 @@ ast_declarator_list::hir(exec_list *instructions,
             this->type->qualifier.image_format = PIPE_FORMAT_R32G32B32A32_FLOAT;
             break;
          default:
-            unreachable("Unknown image format");
+            UNREACHABLE("Unknown image format");
          }
          this->type->qualifier.image_base_type = GLSL_TYPE_FLOAT;
       } else if (strncmp(this->type->specifier->type_name, "uimage", strlen("uimage")) == 0) {
@@ -5034,7 +5034,7 @@ ast_declarator_list::hir(exec_list *instructions,
             this->type->qualifier.image_format = PIPE_FORMAT_R32G32B32A32_UINT;
             break;
          default:
-            unreachable("Unknown image format");
+            UNREACHABLE("Unknown image format");
          }
          this->type->qualifier.image_base_type = GLSL_TYPE_UINT;
       } else if (strncmp(this->type->specifier->type_name, "iimage", strlen("iimage")) == 0) {

--- a/src/compiler/glsl/builtin_functions.cpp
+++ b/src/compiler/glsl/builtin_functions.cpp
@@ -5414,7 +5414,7 @@ builtin_builder::_isinf(builtin_available_predicate avail, const glsl_type *type
          infinities.d[i] = INFINITY;
          break;
       default:
-         unreachable("unknown type");
+         UNREACHABLE("unknown type");
       }
    }
 

--- a/src/compiler/glsl/glcpp/glcpp-lex.c
+++ b/src/compiler/glsl/glcpp/glcpp-lex.c
@@ -1032,7 +1032,7 @@ characters that appear in any other expressions. */
 #define DONE 3
 #define HASH 4
 #define NEWLINE_CATCHUP 5
-#define UNREACHABLE 6
+#define NOT_REACHABLE 6
 
 #define YY_EXTRA_TYPE glcpp_parser_t *
 
@@ -1953,11 +1953,11 @@ YY_RULE_SETUP
 {
 	glcpp_error(yylloc, yyextra, "Internal compiler error: Unexpected character: %s", yytext);
 
-	/* We don't actually use the UNREACHABLE start condition. We
+	/* We don't actually use the NOT_REACHABLE start condition. We
 	only have this block here so that we can pretend to call some
 	generated functions, (to avoid "defined but not used"
 	warnings. */
-        if (YY_START == UNREACHABLE) {
+        if (YY_START == NOT_REACHABLE) {
 		unput('.');
 		yy_top_state(yyextra);
 	}
@@ -1971,7 +1971,7 @@ YY_FATAL_ERROR( "flex scanner jammed" );
 #line 1971 "src/compiler/glsl/glcpp/glcpp-lex.c"
 case YY_STATE_EOF(DONE):
 case YY_STATE_EOF(NEWLINE_CATCHUP):
-case YY_STATE_EOF(UNREACHABLE):
+case YY_STATE_EOF(NOT_REACHABLE):
 	yyterminate();
 
 	case YY_END_OF_BUFFER:

--- a/src/compiler/glsl/glcpp/glcpp-lex.l
+++ b/src/compiler/glsl/glcpp/glcpp-lex.l
@@ -178,7 +178,7 @@ glcpp_lex_update_state_per_token (glcpp_parser_t *parser, int token)
 	 * update the "Internal compiler error" catch-all rule near the end of
 	 * this file. */
 
-%x COMMENT DEFINE DONE HASH NEWLINE_CATCHUP UNREACHABLE
+%x COMMENT DEFINE DONE HASH NEWLINE_CATCHUP NOT_REACHABLE
 
 SPACE		[[:space:]]
 NONSPACE	[^[:space:]]
@@ -602,11 +602,11 @@ PATH			["][]^./ _A-Za-z0-9+*%[(){}|&~=!:;,?-]*["]
 <*>. {
 	glcpp_error(yylloc, yyextra, "Internal compiler error: Unexpected character: %s", yytext);
 
-	/* We don't actually use the UNREACHABLE start condition. We
+	/* We don't actually use the NOT_REACHABLE start condition. We
 	only have this block here so that we can pretend to call some
 	generated functions, (to avoid "defined but not used"
 	warnings. */
-        if (YY_START == UNREACHABLE) {
+        if (YY_START == NOT_REACHABLE) {
 		unput('.');
 		yy_top_state(yyextra);
 	}

--- a/src/compiler/glsl/ir.cpp
+++ b/src/compiler/glsl/ir.cpp
@@ -550,7 +550,7 @@ ir_expression::ir_expression(int op, ir_rvalue *op0, ir_rvalue *op1)
          base = GLSL_TYPE_UINT64;
          break;
       default:
-         unreachable(!"Invalid base type.");
+         UNREACHABLE("Invalid base type.");
       }
 
       this->type = glsl_type::get_instance(base, op0->type->vector_elements, 1);
@@ -623,7 +623,7 @@ ir_expression::get_num_operands(ir_expression_operation op)
    if (op <= ir_last_quadop)
       return 4;
 
-   unreachable("Could not calculate number of operands");
+   UNREACHABLE("Could not calculate number of operands");
 }
 
 #include "ir_expression_operation_strings.h"

--- a/src/compiler/glsl/ir_builder_print_visitor.cpp
+++ b/src/compiler/glsl/ir_builder_print_visitor.cpp
@@ -196,7 +196,7 @@ ir_builder_print_visitor::print_without_declaration(const ir_rvalue *ir)
       print_without_declaration((ir_expression *) ir);
       break;
    default:
-      unreachable("Invalid IR type.");
+      UNREACHABLE("Invalid IR type.");
    }
 }
 
@@ -222,7 +222,7 @@ ir_builder_print_visitor::visit(ir_variable *ir)
    case ir_var_system_value: mode_str = "ir_var_system_value"; break;
    case ir_var_temporary: mode_str = "ir_var_temporary"; break;
    default:
-      unreachable("Invalid variable mode");
+      UNREACHABLE("Invalid variable mode");
    }
 
    if (ir->data.mode == ir_var_temporary) {
@@ -420,7 +420,7 @@ ir_builder_print_visitor::visit(ir_constant *ir)
                print_with_indent("r%04X_data.u[%u] = 1;\n", my_index, i);
             break;
          default:
-            unreachable("Invalid constant type");
+            UNREACHABLE("Invalid constant type");
          }
       }
 

--- a/src/compiler/glsl/ir_expression_operation.py
+++ b/src/compiler/glsl/ir_expression_operation.py
@@ -106,7 +106,7 @@ constant_template_common = mako.template.Template("""\
             break;
     % endfor
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;""")
@@ -137,7 +137,7 @@ constant_template_vector_scalar = mako.template.Template("""\
             break;
     % endfor
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;""")
@@ -160,7 +160,7 @@ constant_template_mul = mako.template.Template("""\
                break;
     % endfor
             default:
-               unreachable("invalid type");
+               UNREACHABLE("invalid type");
             }
          }
       } else {
@@ -218,7 +218,7 @@ constant_template_horizontal = mako.template.Template("""\
          break;
     % endfor
       default:
-         unreachable("invalid type");
+         UNREACHABLE("invalid type");
       }
       break;""")
 
@@ -235,7 +235,7 @@ constant_template_vector_extract = mako.template.Template("""\
          break;
     % endfor
       default:
-         unreachable("invalid type");
+         UNREACHABLE("invalid type");
       }
       break;
    }""")
@@ -254,7 +254,7 @@ constant_template_vector_insert = mako.template.Template("""\
          break;
     % endfor
       default:
-         unreachable("invalid type");
+         UNREACHABLE("invalid type");
       }
       break;
    }""")
@@ -270,7 +270,7 @@ constant_template_vector = mako.template.Template("""\
             break;
     % endfor
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;""")
@@ -291,7 +291,7 @@ constant_template_lrp = mako.template.Template("""\
             break;
     % endfor
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -310,7 +310,7 @@ constant_template_csel = mako.template.Template("""\
             break;
     % endfor
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;""")

--- a/src/compiler/glsl/ir_expression_operation_constant.h
+++ b/src/compiler/glsl/ir_expression_operation_constant.h
@@ -15,7 +15,7 @@
             data.i64[c] = ~ op[0]->value.i64[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -27,7 +27,7 @@
             data.b[c] = !op[0]->value.b[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -54,7 +54,7 @@
             data.i64[c] = -op[0]->value.i64[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -75,7 +75,7 @@
             data.i64[c] = op[0]->value.i64[c] < 0 ? -op[0]->value.i64[c] : op[0]->value.i64[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -96,7 +96,7 @@
             data.i64[c] = (op[0]->value.i64[c] > 0) - (op[0]->value.i64[c] < 0);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -111,7 +111,7 @@
             data.d[c] = 1.0 / op[0]->value.d[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -126,7 +126,7 @@
             data.d[c] = 1.0 / sqrt(op[0]->value.d[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -141,7 +141,7 @@
             data.d[c] = sqrt(op[0]->value.d[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -153,7 +153,7 @@
             data.f[c] = expf(op[0]->value.f[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -165,7 +165,7 @@
             data.f[c] = logf(op[0]->value.f[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -177,7 +177,7 @@
             data.f[c] = exp2f(op[0]->value.f[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -189,7 +189,7 @@
             data.f[c] = log2f(op[0]->value.f[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -201,7 +201,7 @@
             data.i[c] = (int) op[0]->value.f[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -213,7 +213,7 @@
             data.u[c] = (unsigned) op[0]->value.f[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -225,7 +225,7 @@
             data.f[c] = (float) op[0]->value.i[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -237,7 +237,7 @@
             data.b[c] = op[0]->value.f[c] != 0.0F ? true : false;
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -249,7 +249,7 @@
             data.f[c] = op[0]->value.b[c] ? 1.0F : 0.0F;
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -261,7 +261,7 @@
             data.f[c] = op[0]->value.b[c] ? 1.0F : 0.0F;
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -276,7 +276,7 @@
             data.b[c] = op[0]->value.i[c] ? true : false;
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -288,7 +288,7 @@
             data.i[c] = op[0]->value.b[c] ? 1 : 0;
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -300,7 +300,7 @@
             data.f[c] = (float) op[0]->value.u[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -312,7 +312,7 @@
             data.u[c] = op[0]->value.i[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -324,7 +324,7 @@
             data.i[c] = op[0]->value.u[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -336,7 +336,7 @@
             data.f[c] = op[0]->value.d[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -348,7 +348,7 @@
             data.d[c] = op[0]->value.f[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -360,7 +360,7 @@
             data.f[c] = op[0]->value.f[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -372,7 +372,7 @@
             data.f[c] = op[0]->value.f[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -384,7 +384,7 @@
             data.f[c] = op[0]->value.f[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -396,7 +396,7 @@
             data.i[c] = op[0]->value.d[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -408,7 +408,7 @@
             data.d[c] = op[0]->value.i[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -420,7 +420,7 @@
             data.u[c] = op[0]->value.d[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -432,7 +432,7 @@
             data.d[c] = op[0]->value.u[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -444,7 +444,7 @@
             data.b[c] = op[0]->value.d[c] != 0.0;
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -456,7 +456,7 @@
             data.b[c] = op[0]->value.f[c] != 0.0;
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -468,7 +468,7 @@
             data.f[c] = bitcast_u2f(op[0]->value.i[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -480,7 +480,7 @@
             data.i[c] = bitcast_f2u(op[0]->value.f[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -492,7 +492,7 @@
             data.f[c] = bitcast_u2f(op[0]->value.u[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -504,7 +504,7 @@
             data.u[c] = bitcast_f2u(op[0]->value.f[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -516,7 +516,7 @@
             data.d[c] = bitcast_u642d(op[0]->value.u64[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -528,7 +528,7 @@
             data.d[c] = bitcast_i642d(op[0]->value.i64[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -540,7 +540,7 @@
             data.u64[c] = bitcast_d2u64(op[0]->value.d[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -552,7 +552,7 @@
             data.i64[c] = bitcast_d2i64(op[0]->value.d[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -564,7 +564,7 @@
             data.i[c] = op[0]->value.i64[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -576,7 +576,7 @@
             data.i[c] = op[0]->value.u64[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -588,7 +588,7 @@
             data.u[c] = op[0]->value.i64[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -600,7 +600,7 @@
             data.u[c] = op[0]->value.u64[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -612,7 +612,7 @@
             data.b[c] = op[0]->value.i64[c] != 0;
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -624,7 +624,7 @@
             data.f[c] = op[0]->value.i64[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -636,7 +636,7 @@
             data.f[c] = op[0]->value.u64[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -648,7 +648,7 @@
             data.d[c] = op[0]->value.i64[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -660,7 +660,7 @@
             data.d[c] = op[0]->value.u64[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -672,7 +672,7 @@
             data.i64[c] = op[0]->value.i[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -684,7 +684,7 @@
             data.i64[c] = op[0]->value.u[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -696,7 +696,7 @@
             data.i64[c] = op[0]->value.b[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -708,7 +708,7 @@
             data.i64[c] = op[0]->value.f[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -720,7 +720,7 @@
             data.i64[c] = op[0]->value.d[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -732,7 +732,7 @@
             data.u64[c] = op[0]->value.i[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -744,7 +744,7 @@
             data.u64[c] = op[0]->value.u[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -756,7 +756,7 @@
             data.u64[c] = op[0]->value.f[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -768,7 +768,7 @@
             data.u64[c] = op[0]->value.d[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -780,7 +780,7 @@
             data.i64[c] = op[0]->value.u64[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -792,7 +792,7 @@
             data.u64[c] = op[0]->value.i64[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -807,7 +807,7 @@
             data.d[c] = trunc(op[0]->value.d[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -822,7 +822,7 @@
             data.d[c] = ceil(op[0]->value.d[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -837,7 +837,7 @@
             data.d[c] = floor(op[0]->value.d[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -852,7 +852,7 @@
             data.d[c] = op[0]->value.d[c] - floor(op[0]->value.d[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -867,7 +867,7 @@
             data.d[c] = _mesa_roundeven(op[0]->value.d[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -879,7 +879,7 @@
             data.f[c] = sinf(op[0]->value.f[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -891,7 +891,7 @@
             data.f[c] = cosf(op[0]->value.f[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -903,7 +903,7 @@
             data.f[c] = atan(op[0]->value.f[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -915,7 +915,7 @@
             data.f[c] = 0.0f;
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -927,7 +927,7 @@
             data.f[c] = 0.0f;
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -939,7 +939,7 @@
             data.f[c] = 0.0f;
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -951,7 +951,7 @@
             data.f[c] = 0.0f;
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -963,7 +963,7 @@
             data.f[c] = 0.0f;
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -975,7 +975,7 @@
             data.f[c] = 0.0f;
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -986,7 +986,7 @@
          data.u[0] = pack_2x16(pack_snorm_1x16, op[0]->value.f[0], op[0]->value.f[1]);
          break;
       default:
-         unreachable("invalid type");
+         UNREACHABLE("invalid type");
       }
       break;
 
@@ -996,7 +996,7 @@
          data.u[0] = pack_4x8(pack_snorm_1x8, op[0]->value.f[0], op[0]->value.f[1], op[0]->value.f[2], op[0]->value.f[3]);
          break;
       default:
-         unreachable("invalid type");
+         UNREACHABLE("invalid type");
       }
       break;
 
@@ -1006,7 +1006,7 @@
          data.u[0] = pack_2x16(pack_unorm_1x16, op[0]->value.f[0], op[0]->value.f[1]);
          break;
       default:
-         unreachable("invalid type");
+         UNREACHABLE("invalid type");
       }
       break;
 
@@ -1016,7 +1016,7 @@
          data.u[0] = pack_4x8(pack_unorm_1x8, op[0]->value.f[0], op[0]->value.f[1], op[0]->value.f[2], op[0]->value.f[3]);
          break;
       default:
-         unreachable("invalid type");
+         UNREACHABLE("invalid type");
       }
       break;
 
@@ -1026,7 +1026,7 @@
          data.u[0] = pack_2x16(pack_half_1x16, op[0]->value.f[0], op[0]->value.f[1]);
          break;
       default:
-         unreachable("invalid type");
+         UNREACHABLE("invalid type");
       }
       break;
 
@@ -1060,7 +1060,7 @@
             data.i[c] = bitfield_reverse(op[0]->value.i[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1075,7 +1075,7 @@
             data.i[c] = util_bitcount(op[0]->value.i[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1090,7 +1090,7 @@
             data.i[c] = find_msb_int(op[0]->value.i[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1105,7 +1105,7 @@
             data.i[c] = find_msb_uint(op[0]->value.i[c] & -op[0]->value.i[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1117,7 +1117,7 @@
             data.u[c] = (unsigned)(31 - find_msb_uint(op[0]->value.u[c]));
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1129,7 +1129,7 @@
             data.f[c] = CLAMP(op[0]->value.f[c], 0.0f, 1.0f);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1200,7 +1200,7 @@
             data.i64[c] = op[0]->value.i64[c0] + op[1]->value.i64[c1];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1231,7 +1231,7 @@
             data.i64[c] = op[0]->value.i64[c0] - op[1]->value.i64[c1];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1252,7 +1252,7 @@
             data.i64[c] = iadd64_saturate(op[0]->value.i64[c], op[1]->value.i64[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1273,7 +1273,7 @@
             data.i64[c] = isub64_saturate(op[0]->value.i64[c], op[1]->value.i64[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1294,7 +1294,7 @@
             data.i64[c] = (op[1]->value.i64[c] > op[0]->value.i64[c]) ? (uint64_t)op[1]->value.i64[c] - (uint64_t)op[0]->value.i64[c] : (uint64_t)op[0]->value.i64[c] - (uint64_t)op[1]->value.i64[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1315,7 +1315,7 @@
             data.i64[c] = (op[0]->value.i64[c] >> 1) + (op[1]->value.i64[c] >> 1) + ((op[0]->value.i64[c] & op[1]->value.i64[c]) & 1);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1336,7 +1336,7 @@
             data.i64[c] = (op[0]->value.i64[c] >> 1) + (op[1]->value.i64[c] >> 1) + ((op[0]->value.i64[c] | op[1]->value.i64[c]) & 1);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1369,7 +1369,7 @@
                data.i64[c] = op[0]->value.i64[c0] * op[1]->value.i64[c1];
                break;
             default:
-               unreachable("invalid type");
+               UNREACHABLE("invalid type");
             }
          }
       } else {
@@ -1411,7 +1411,7 @@
             data.i[c] = op[0]->value.i[c] * (int16_t)op[0]->value.i[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1442,7 +1442,7 @@
             data.i64[c] = op[1]->value.i64[c1] == 0 ? 0 : op[0]->value.i64[c0] / op[1]->value.i64[c1];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1473,7 +1473,7 @@
             data.i64[c] = op[1]->value.i64[c1] == 0 ? 0 : op[0]->value.i64[c0] % op[1]->value.i64[c1];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1500,7 +1500,7 @@
             data.b[c] = op[0]->value.i64[c] < op[1]->value.i64[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1527,7 +1527,7 @@
             data.b[c] = op[0]->value.i64[c] >= op[1]->value.i64[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1557,7 +1557,7 @@
             data.b[c] = op[0]->value.b[c] == op[1]->value.b[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1587,7 +1587,7 @@
             data.b[c] = op[0]->value.b[c] != op[1]->value.b[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1627,7 +1627,7 @@
             data.i64[c] = op[0]->value.i64[c0] << op[1]->value.i64[c1];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1659,7 +1659,7 @@
             data.i64[c] = op[0]->value.i64[c0] >> op[1]->value.i64[c1];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1684,7 +1684,7 @@
             data.i64[c] = op[0]->value.i64[c0] & op[1]->value.i64[c1];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1709,7 +1709,7 @@
             data.i64[c] = op[0]->value.i64[c0] ^ op[1]->value.i64[c1];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1734,7 +1734,7 @@
             data.i64[c] = op[0]->value.i64[c0] | op[1]->value.i64[c1];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1746,7 +1746,7 @@
             data.b[c] = op[0]->value.b[c] && op[1]->value.b[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1758,7 +1758,7 @@
             data.b[c] = op[0]->value.b[c] != op[1]->value.b[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1770,7 +1770,7 @@
             data.b[c] = op[0]->value.b[c] || op[1]->value.b[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1784,7 +1784,7 @@
          data.d[0] = dot_d(op[0], op[1]);
          break;
       default:
-         unreachable("invalid type");
+         UNREACHABLE("invalid type");
       }
       break;
 
@@ -1814,7 +1814,7 @@
             data.i64[c] = MIN2(op[0]->value.i64[c0], op[1]->value.i64[c1]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1845,7 +1845,7 @@
             data.i64[c] = MAX2(op[0]->value.i64[c0], op[1]->value.i64[c1]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1857,7 +1857,7 @@
             data.f[c] = powf(op[0]->value.f[c], op[1]->value.f[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1872,7 +1872,7 @@
             data.d[c] = ldexp_flush_subnormal(op[0]->value.d[c], op[1]->value.i[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1904,7 +1904,7 @@
          data.b[0] = op[0]->value.b[c];
          break;
       default:
-         unreachable("invalid type");
+         UNREACHABLE("invalid type");
       }
       break;
    }
@@ -1916,7 +1916,7 @@
             data.f[c] = atan2(op[0]->value.f[c], op[1]->value.f[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1931,7 +1931,7 @@
             data.d[c] = op[0]->value.d[c] * op[1]->value.d[c] + op[2]->value.d[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1951,7 +1951,7 @@
             data.d[c] = op[0]->value.d[c] * (1.0 - op[2]->value.d[c2]) + (op[1]->value.d[c] * op[2]->value.d[c2]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1982,7 +1982,7 @@
             data.b[c] = op[0]->value.b[c] ? op[1]->value.b[c] : op[2]->value.b[c];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -1997,7 +1997,7 @@
             data.i[c] = bitfield_extract_int(op[0]->value.i[c], op[1]->value.i[c], op[2]->value.i[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -2030,7 +2030,7 @@
          data.b[idx] = op[1]->value.b[0];
          break;
       default:
-         unreachable("invalid type");
+         UNREACHABLE("invalid type");
       }
       break;
    }
@@ -2045,7 +2045,7 @@
             data.i[c] = bitfield_insert(op[0]->value.i[c], op[1]->value.i[c], op[2]->value.i[c], op[3]->value.i[c]);
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;
@@ -2075,7 +2075,7 @@
             data.b[c] = op[c]->value.b[0];
             break;
          default:
-            unreachable("invalid type");
+            UNREACHABLE("invalid type");
          }
       }
       break;

--- a/src/compiler/glsl/ir_print_glsl_visitor.cpp
+++ b/src/compiler/glsl/ir_print_glsl_visitor.cpp
@@ -835,7 +835,7 @@ static const char* operator_glsl_str(ir_expression_operation op, const glsl_type
 	case ir_triop_lrp:
 		return "mix";
 	default:
-		unreachable("Unexpected operator in operator_glsl_str");
+		UNREACHABLE("Unexpected operator in operator_glsl_str");
 		return "UNIMPLEMENTED";
 	}
 }
@@ -1891,7 +1891,7 @@ interface_packing_string(enum glsl_interface_packing packing)
 	case GLSL_INTERFACE_PACKING_STD430:
 		return "std430";
 	default:
-		unreachable("Unexpected interface packing");
+		UNREACHABLE("Unexpected interface packing");
 		return "UNKNOWN";
 	}
 }
@@ -1905,7 +1905,7 @@ interface_variable_mode_string(enum ir_variable_mode mode)
 	case ir_var_shader_storage:
 		return "buffer";
 	default:
-		unreachable("Unexpected interface variable mode");
+		UNREACHABLE("Unexpected interface variable mode");
 		return "UNKOWN";
 	}
 }

--- a/src/compiler/glsl/ir_print_visitor.cpp
+++ b/src/compiler/glsl/ir_print_visitor.cpp
@@ -381,7 +381,7 @@ void ir_print_visitor::visit(ir_texture *ir)
       ir->lod_info.component->accept(this);
       break;
    case ir_samples_identical:
-      unreachable("ir_samples_identical was already handled");
+      UNREACHABLE("ir_samples_identical was already handled");
    };
    fprintf(f, ")");
 }
@@ -522,7 +522,7 @@ void ir_print_visitor::visit(ir_constant *ir)
                fprintf(f, "%f", ir->value.d[i]);
             break;
 	 default:
-            unreachable("Invalid constant type");
+            UNREACHABLE("Invalid constant type");
 	 }
       }
    }

--- a/src/compiler/glsl/linker.cpp
+++ b/src/compiler/glsl/linker.cpp
@@ -3988,7 +3988,7 @@ add_packed_varyings(const struct gl_context *ctx,
             iface = GL_PROGRAM_OUTPUT;
             break;
          default:
-            unreachable("unexpected type");
+            UNREACHABLE("unexpected type");
          }
 
          if (type == iface) {

--- a/src/compiler/glsl/loop_analysis.cpp
+++ b/src/compiler/glsl/loop_analysis.cpp
@@ -171,7 +171,7 @@ calculate_iterations(ir_rvalue *from, ir_rvalue *to, ir_rvalue *increment,
          iter = new(mem_ctx) ir_constant(double(iter_value + bias[i]));
          break;
       default:
-          unreachable("Unsupported type for loop iterator.");
+          UNREACHABLE("Unsupported type for loop iterator.");
       }
 
       ir_expression *const mul =
@@ -238,7 +238,7 @@ incremented_before_terminator(ir_loop *loop, ir_variable *var,
       }
    }
 
-   unreachable("Unable to find induction variable");
+   UNREACHABLE("Unable to find induction variable");
 }
 
 /**

--- a/src/compiler/glsl/lower_blend_equation_advanced.cpp
+++ b/src/compiler/glsl/lower_blend_equation_advanced.cpp
@@ -386,7 +386,7 @@ calc_blend_result(ir_factory f,
          break;
       case BLEND_NONE:
       case BLEND_ALL:
-         unreachable("not real cases");
+         UNREACHABLE("not real cases");
       }
 
       if (val)

--- a/src/compiler/glsl/lower_buffer_access.cpp
+++ b/src/compiler/glsl/lower_buffer_access.cpp
@@ -244,7 +244,7 @@ lower_buffer_access::is_dereferenced_thing_row_major(const ir_rvalue *deref)
             return matrix || deref->type->without_array()->is_struct();
          }
 
-         unreachable("invalid matrix layout");
+         UNREACHABLE("invalid matrix layout");
          break;
       }
 
@@ -256,7 +256,7 @@ lower_buffer_access::is_dereferenced_thing_row_major(const ir_rvalue *deref)
    /* The tree must have ended with a dereference that wasn't an
     * ir_dereference_variable.  That is invalid, and it should be impossible.
     */
-   unreachable("invalid dereference tree");
+   UNREACHABLE("invalid dereference tree");
    return false;
 }
 

--- a/src/compiler/glsl/lower_distance.cpp
+++ b/src/compiler/glsl/lower_distance.cpp
@@ -155,7 +155,7 @@ lower_distance_visitor::visit(ir_variable *ir)
       old_var = &old_distance_in_var;
       new_var = &new_distance_in_var;
    } else {
-      unreachable("not reached");
+      UNREACHABLE("not reached");
    }
 
    this->progress = true;

--- a/src/compiler/glsl/lower_ubo_reference.cpp
+++ b/src/compiler/glsl/lower_ubo_reference.cpp
@@ -549,7 +549,7 @@ lower_ubo_reference_visitor::insert_buffer_access(void *mem_ctx,
       }
       break;
    default:
-      unreachable("invalid buffer_access_type in insert_buffer_access");
+      UNREACHABLE("invalid buffer_access_type in insert_buffer_access");
    }
 }
 
@@ -730,7 +730,7 @@ lower_ubo_reference_visitor::calculate_unsized_array_stride(ir_dereference *dere
       break;
    }
    default:
-      unreachable("Unsupported dereference type");
+      UNREACHABLE("Unsupported dereference type");
    }
    return array_stride;
 }

--- a/src/compiler/glsl/opt_algebraic.cpp
+++ b/src/compiler/glsl/opt_algebraic.cpp
@@ -995,7 +995,7 @@ ir_algebraic_visitor::handle_expression(ir_expression *ir)
             break;
          default:
             one = NULL;
-            unreachable("unexpected type");
+            UNREACHABLE("unexpected type");
          }
 
          return mul(ir->operands[0], add(one, neg(ir->operands[2])));

--- a/src/compiler/glsl/opt_minmax.cpp
+++ b/src/compiler/glsl/opt_minmax.cpp
@@ -154,7 +154,7 @@ compare_components(ir_constant *a, ir_constant *b)
             foundequal = true;
          break;
       default:
-         unreachable("not reached");
+         UNREACHABLE("not reached");
       }
    }
 

--- a/src/compiler/glsl/opt_vectorize.cpp
+++ b/src/compiler/glsl/opt_vectorize.cpp
@@ -228,7 +228,7 @@ write_mask_to_swizzle(unsigned write_mask)
    case WRITEMASK_Z: return SWIZZLE_Z;
    case WRITEMASK_W: return SWIZZLE_W;
    }
-   unreachable("not reached");
+   UNREACHABLE("not reached");
 }
 
 /**

--- a/src/compiler/glsl_types.cpp
+++ b/src/compiler/glsl_types.cpp
@@ -459,7 +459,7 @@ const glsl_type *glsl_type::get_bare_type() const
       return this;
    }
 
-   unreachable("Invalid base type");
+   UNREACHABLE("Invalid base type");
 }
 
 const glsl_type *glsl_type::get_float16_type() const
@@ -899,7 +899,7 @@ glsl_type::get_sampler_instance(enum glsl_sampler_dim dim,
       return error_type;
    }
 
-   unreachable("switch statement above should be complete");
+   UNREACHABLE("switch statement above should be complete");
 }
 
 const glsl_type *
@@ -998,7 +998,7 @@ glsl_type::get_image_instance(enum glsl_sampler_dim dim,
       return error_type;
    }
 
-   unreachable("switch statement above should be complete");
+   UNREACHABLE("switch statement above should be complete");
 }
 
 const glsl_type *
@@ -2015,7 +2015,7 @@ glsl_type::get_explicit_std140_type(bool row_major) const
       delete[] fields;
       return type;
    } else {
-      unreachable("Invalid type for UBO or SSBO");
+      UNREACHABLE("Invalid type for UBO or SSBO");
    }
 }
 
@@ -2373,7 +2373,7 @@ glsl_type::get_explicit_std430_type(bool row_major) const
       delete[] fields;
       return type;
    } else {
-      unreachable("Invalid type for SSBO");
+      UNREACHABLE("Invalid type for SSBO");
    }
 }
 
@@ -2447,7 +2447,7 @@ glsl_type::get_explicit_type_for_size_align(glsl_type_size_align_func type_info,
       return glsl_type::get_instance(this->base_type, this->vector_elements,
                                      this->matrix_columns, stride, false);
    } else {
-      unreachable("Unhandled type.");
+      UNREACHABLE("Unhandled type.");
    }
 }
 
@@ -2583,7 +2583,7 @@ glsl_type::count_dword_slots(bool is_bindless) const
    case GLSL_TYPE_ERROR:
    case GLSL_TYPE_FUNCTION:
    default:
-      unreachable("invalid type in st_glsl_type_dword_size()");
+      UNREACHABLE("invalid type in st_glsl_type_dword_size()");
    }
 
    return 0;
@@ -2947,7 +2947,7 @@ glsl_get_sampler_dim_coordinate_components(enum glsl_sampler_dim dim)
    case GLSL_SAMPLER_DIM_CUBE:
       return 3;
    default:
-      unreachable("Unknown sampler dim");
+      UNREACHABLE("Unknown sampler dim");
    }
 }
 

--- a/src/compiler/glsl_types.h
+++ b/src/compiler/glsl_types.h
@@ -187,7 +187,7 @@ glsl_base_type_get_bit_size(const enum glsl_base_type base_type)
       return 64;
 
    default:
-      unreachable("unknown base type");
+      UNREACHABLE("unknown base type");
    }
 
    return 0;

--- a/src/compiler/shader_enums.c
+++ b/src/compiler/shader_enums.c
@@ -66,7 +66,7 @@ _mesa_shader_stage_to_string(unsigned stage)
    case MESA_SHADER_TESS_EVAL: return "tessellation evaluation";
    }
 
-   unreachable("Unknown shader stage.");
+   UNREACHABLE("Unknown shader stage.");
 }
 
 /**
@@ -86,7 +86,7 @@ _mesa_shader_stage_to_abbrev(unsigned stage)
    case MESA_SHADER_TESS_EVAL: return "TES";
    }
 
-   unreachable("Unknown shader stage.");
+   UNREACHABLE("Unknown shader stage.");
 }
 
 const char *

--- a/src/mesa/main/shaderobj.h
+++ b/src/mesa/main/shaderobj.h
@@ -140,7 +140,7 @@ _mesa_shader_enum_to_shader_stage(GLenum v)
    case GL_COMPUTE_SHADER:
       return MESA_SHADER_COMPUTE;
    default:
-      unreachable("bad value in _mesa_shader_enum_to_shader_stage()");
+      UNREACHABLE("bad value in _mesa_shader_enum_to_shader_stage()");
    }
 }
 
@@ -184,7 +184,7 @@ _mesa_shader_stage_from_subroutine_uniform(GLenum subuniform)
    case GL_TESS_EVALUATION_SUBROUTINE_UNIFORM:
       return MESA_SHADER_TESS_EVAL;
    }
-   unreachable("not reached");
+   UNREACHABLE("not reached");
 }
 
 static inline gl_shader_stage
@@ -204,7 +204,7 @@ _mesa_shader_stage_from_subroutine(GLenum subroutine)
    case GL_TESS_EVALUATION_SUBROUTINE:
       return MESA_SHADER_TESS_EVAL;
    }
-   unreachable("not reached");
+   UNREACHABLE("not reached");
 }
 
 static inline GLenum
@@ -226,10 +226,10 @@ _mesa_shader_stage_to_subroutine(gl_shader_stage stage)
    case MESA_SHADER_NONE:
       break;
    case MESA_SHADER_KERNEL:
-      unreachable("not reached");
+      UNREACHABLE("not reached");
       break;
    }
-   unreachable("not reached");
+   UNREACHABLE("not reached");
 }
 
 static inline GLenum
@@ -252,7 +252,7 @@ _mesa_shader_stage_to_subroutine_uniform(gl_shader_stage stage)
    case MESA_SHADER_KERNEL:
       break;
    }
-   unreachable("not reached");
+   UNREACHABLE("not reached");
 }
 
 extern bool

--- a/src/util/macros.h
+++ b/src/util/macros.h
@@ -72,20 +72,30 @@
  * Unreachable macro. Useful for suppressing "control reaches end of non-void
  * function" warnings.
  */
+/**
+ * Unreachable macro. Useful for suppressing "control reaches end of non-void
+ * function" warnings.
+ */
 #if defined(HAVE___BUILTIN_UNREACHABLE) || __has_builtin(__builtin_unreachable)
-#define unreachable(str)    \
+#define UNREACHABLE(str)    \
 do {                        \
+   (void)"" str; /* str must be a string literal */ \
    assert(!str);            \
    __builtin_unreachable(); \
 } while (0)
 #elif defined (_MSC_VER)
-#define unreachable(str)    \
+#define UNREACHABLE(str)    \
 do {                        \
+   (void)"" str; /* str must be a string literal */ \
    assert(!str);            \
    __assume(0);             \
 } while (0)
 #else
-#define unreachable(str) assert(!str)
+#define UNREACHABLE(str)    \
+do {                        \
+   (void)"" str; /* str must be a string literal */ \
+   assert(!str);            \
+} while (0)
 #endif
 
 /**


### PR DESCRIPTION
glsl-optimizer's macros.h #defines a macro called unreachable() whose name conflicts with C++23's new `std::unreachable()` function declaration in the <utility> std library header.

https://en.cppreference.com/w/cpp/utility/unreachable

```
warning: ~/.mozbuild/MacOSX14.2.sdk/usr/include/c++/v1/__utility/unreachable.h:28:48: error: expected unqualified-id
warning:    28 | [[noreturn]] _LIBCPP_HIDE_FROM_ABI inline void unreachable() { __libcpp_unreachable(); }
warning: third_party/rust/glslopt/glsl-optimizer/src/util/macros.h:76:29: note: expanded from macro 'unreachable'
warning:    76 | #define unreachable(str)
```