### PR TITLE
Fix -Wdeprecated-builtins warnings about __has_trivial_destructor

### DIFF
--- a/src/util/macros.h
+++ b/src/util/macros.h
@@ -190,8 +190,10 @@ do {                       \
  * performs no action and all member variables and base classes are
  * trivially destructible themselves.
  */
-#   if (defined(__clang__) && defined(__has_feature))
-#      if __has_feature(has_trivial_destructor)
+#   if defined(__clang__)
+#      if __has_builtin(__is_trivially_destructible)
+#         define HAS_TRIVIAL_DESTRUCTOR(T) __is_trivially_destructible(T)
+#      elif (defined(__has_feature) && __has_feature(has_trivial_destructor))
 #         define HAS_TRIVIAL_DESTRUCTOR(T) __has_trivial_destructor(T)
 #      endif
 #   elif defined(__GNUC__)


### PR DESCRIPTION
```
warning: glsl-optimizer/src/compiler/glsl/list.h:58:4: warning: builtin __has_trivial_destructor is deprecated; use __is_trivially_destructible instead [-Wdeprecated-builtins] ...
warning: glsl-optimizer/src/util/macros.h:195:44: note: expanded from macro 'HAS_TRIVIAL_DESTRUCTOR'
warning:   195 | #         define HAS_TRIVIAL_DESTRUCTOR(T) __has_trivial_destructor(T)
warning:       |                                            ^
```

clang recommends replacing __has_trivial_destructor with __is_trivially_destructible, but we can use C++11's standard `std::is_trivially_destructible` directly; it's been available in clang and gcc since 2013 (clang 3.3 and gcc 4.8) and at least MSVC 2019.

https://en.cppreference.com/w/cpp/types/is_destructible