### PR TITLE
Implement ffs also when `_M_ARM64`

### DIFF
--- a/src/util/bitscan.h
+++ b/src/util/bitscan.h
@@ -55,7 +55,7 @@ extern "C" {
  */
 #ifdef HAVE___BUILTIN_FFS
 #define ffs __builtin_ffs
-#elif defined(_MSC_VER) && (_M_IX86 || _M_ARM || _M_AMD64 || _M_IA64)
+#elif defined(_MSC_VER) && (_M_IX86 || _M_ARM || _M_AMD64 || _M_ARM64 || _M_IA64)
 static inline
 int ffs(int i)
 {


### PR DESCRIPTION
Doing this fixes webrender and Firefox builds. A simple WebGL demo looked identical. Given `ffsll` below already includes ARM64, I wonder it's just accidentally omitted.

Closes #12 