### PR TITLE
Fix conflicting types for `once_flag` and `call_once` with glibc 2.43

### DIFF
--- a/include/c11/threads_posix.h
+++ b/include/c11/threads_posix.h
@@ -51,7 +51,9 @@ Configuration macro:
 #include <pthread.h>
 
 /*---------------------------- macros ----------------------------*/
+#ifndef __once_flag_defined
 #define ONCE_FLAG_INIT PTHREAD_ONCE_INIT
+#endif
 #ifdef INIT_ONCE_STATIC_INIT
 #define TSS_DTOR_ITERATIONS PTHREAD_DESTRUCTOR_ITERATIONS
 #else
@@ -66,7 +68,9 @@ typedef pthread_cond_t  cnd_t;
 typedef pthread_t       thrd_t;
 typedef pthread_key_t   tss_t;
 typedef pthread_mutex_t mtx_t;
+#ifndef __once_flag_defined
 typedef pthread_once_t  once_flag;
+#endif
 
 
 /*
@@ -90,11 +94,13 @@ impl_thrd_routine(void *p)
 
 /*--------------- 7.25.2 Initialization functions ---------------*/
 // 7.25.2.1
+#ifndef __once_flag_defined
 static inline void
 call_once(once_flag *flag, void (*func)(void))
 {
     pthread_once(flag, func);
 }
+#endif
 
 
 /*------------- 7.25.3 Condition variable functions -------------*/


### PR DESCRIPTION
Starting from glibc 2.43, once_flag and call_once are added to stdlib.h for C23. (See commit a7ddbf4 of the glibc repository.)

https://sourceware.org/cgit/glibc/commit/?id=a7ddbf456d97ac8d1aa7afd735e196a1488bd874

This conflicts with the definition of once_flag and call_once in include/c11/threads_posix.h.

~~Wrap the definition in include/c11/threads_posix.h with a new configuration macro `ONCE_FLAG_USE_PTHREAD_ONCE`, which is disabled when ONCE_FLAG_INIT is enabled by glibc, to avoid the conflict.~~

Wrap the definition `once_flag` and `call_once` in `include/c11/threads_posix.h` with the preprocessor flag `__once_flag_defined` to avoid conflicting with the definition in `stdlib.h`.

Close #15 