### PR TITLE
util: Add namespace over float16_t in half_float.h

### DIFF
--- a/src/compiler/glsl/ir.cpp
+++ b/src/compiler/glsl/ir.cpp
@@ -689,7 +689,7 @@ ir_constant::ir_constant(const struct glsl_type *type,
    memcpy(& this->value, data, sizeof(this->value));
 }
 
-ir_constant::ir_constant(float16_t f16, unsigned vector_elements)
+ir_constant::ir_constant(mesa::float16_t f16, unsigned vector_elements)
    : ir_rvalue(ir_type_constant)
 {
    assert(vector_elements <= 4);

--- a/src/compiler/glsl/ir.h
+++ b/src/compiler/glsl/ir.h
@@ -2224,7 +2224,7 @@ public:
    ir_constant(bool b, unsigned vector_elements=1);
    ir_constant(unsigned int u, unsigned vector_elements=1);
    ir_constant(int i, unsigned vector_elements=1);
-   ir_constant(float16_t f16, unsigned vector_elements=1);
+   ir_constant(mesa::float16_t f16, unsigned vector_elements=1);
    ir_constant(float f, unsigned vector_elements=1);
    ir_constant(double d, unsigned vector_elements=1);
    ir_constant(uint64_t u64, unsigned vector_elements=1);

--- a/src/compiler/glsl/lower_instructions.cpp
+++ b/src/compiler/glsl/lower_instructions.cpp
@@ -1535,7 +1535,7 @@ lower_instructions_visitor::_imm_fp(void *mem_ctx,
    case GLSL_TYPE_DOUBLE:
       return new(mem_ctx) ir_constant((double) f, vector_elements);
    case GLSL_TYPE_FLOAT16:
-      return new(mem_ctx) ir_constant(float16_t(f), vector_elements);
+      return new(mem_ctx) ir_constant(mesa::float16_t(f), vector_elements);
    default:
       assert(!"unknown float type for immediate");
       return NULL;

--- a/src/compiler/glsl/opt_algebraic.cpp
+++ b/src/compiler/glsl/opt_algebraic.cpp
@@ -985,7 +985,7 @@ ir_algebraic_visitor::handle_expression(ir_expression *ir)
 
          switch (ir->type->base_type) {
          case GLSL_TYPE_FLOAT16:
-            one = new(mem_ctx) ir_constant(float16_t::one(), op2_components);
+            one = new(mem_ctx) ir_constant(mesa::float16_t::one(), op2_components);
             break;
          case GLSL_TYPE_FLOAT:
             one = new(mem_ctx) ir_constant(1.0f, op2_components);

--- a/src/util/half_float.h
+++ b/src/util/half_float.h
@@ -64,6 +64,8 @@ _mesa_half_is_negative(uint16_t h)
 
 #ifdef __cplusplus
 
+namespace mesa {
+
 /* Helper class for disambiguating fp16 from uint16_t in C++ overloads */
 
 struct float16_t {
@@ -74,6 +76,8 @@ struct float16_t {
    static float16_t one() { return float16_t(FP16_ONE); }
    static float16_t zero() { return float16_t(FP16_ZERO); }
 };
+
+} /* namespace mesa */
 
 #endif
 


### PR DESCRIPTION
Fixes #16 
Closes #14 

This applies but still deviates from https://gitlab.freedesktop.org/mesa/mesa/-/commit/2a6ac3a79c871362003112d7957b8357e71b019b, by not defining an alias but using namespace explicitly on each reference.

I was concerned with macros here:

https://github.com/jamienicol/glsl-optimizer/blob/77fea851468286e3bc5409c36b2b8a6fb495b28b/src/compiler/builtin_type_macros.h#L34-L40

https://github.com/jamienicol/glsl-optimizer/blob/77fea851468286e3bc5409c36b2b8a6fb495b28b/src/compiler/builtin_type_macros.h#L46

But apparently every use of the macro only uses float16_t as a string instead of a type reference, e.g.:

https://github.com/jamienicol/glsl-optimizer/blob/77fea851468286e3bc5409c36b2b8a6fb495b28b/src/compiler/glsl_types.h#L344-L349

And this makes Firefox build without error locally. Submitted try run to confirm that this doesn't cause regression: https://treeherder.mozilla.org/jobs?repo=try&revision=f943934ab8da442fff5a469adac2c66ca43f9cea